### PR TITLE
Fix: HR/HRV data aggregation for different API formats

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1092,12 +1092,25 @@
                     case "temp":
                     case "hrv":
                     case "night_rhr":
-                        const avgValue = metrics.reduce((sum, m) => sum + (m.object.avg || m.object.last_reading || 0), 0) / metrics.length;
-                        const unit = metrics[0]?.object.unit || (metricType === "hrv" ? "ms" : "");
+                        // Filter out invalid metrics and safely extract values
+                        const validMetrics = metrics.filter(m => m && m.object);
+                        const avgValue = validMetrics.reduce((sum, m) => {
+                            const avg = safeGet(m, 'object.avg', 0);
+                            const lastReading = safeGet(m, 'object.last_reading', 0);
+                            const value = safeGet(m, 'object.value', 0);
+                            return sum + (avg || lastReading || value || 0);
+                        }, 0) / (validMetrics.length || 1);
+                        
+                        const unit = safeGet(validMetrics[0], 'object.unit', '') || (metricType === "hrv" ? "ms" : "");
                         content += `<div class="metric-value">${avgValue.toFixed(1)} <span class="metric-unit">${unit} (Avg)</span></div>`;
                         
-                        // Show range if available
-                        const hrValues = metrics.map(m => m.object.avg || m.object.last_reading || 0).filter(v => v > 0);
+                        // Show range if available - use safe extraction
+                        const hrValues = validMetrics.map(m => {
+                            const avg = safeGet(m, 'object.avg', 0);
+                            const lastReading = safeGet(m, 'object.last_reading', 0);
+                            const value = safeGet(m, 'object.value', 0);
+                            return avg || lastReading || value || 0;
+                        }).filter(v => v > 0);
                         if (hrValues.length > 0) {
                             const minVal = Math.min(...hrValues);
                             const maxVal = Math.max(...hrValues);


### PR DESCRIPTION
## 🐛 Problem
Remaining JavaScript error when processing HR data for Omar's account:
```
TypeError: Cannot read properties of undefined (reading 'avg')
```

**Root Cause:** HR metrics aggregation at line 1095 failed because Omar's HR data uses `last_reading` instead of `avg` property, and some metrics in the array had null/undefined objects.

## ✅ Solution
**Enhanced Data Aggregation with Safe Property Access:**
- Replaced unsafe property access with `safeGet()` utility function
- Added defensive filtering to remove invalid metrics before processing
- Enhanced fallback chain: `avg` → `last_reading` → `value` → `0`
- Applied same fix to range calculation code

## 🔧 Technical Changes
- Updated HR/HRV aggregation logic in `displayAggregatedMetrics()`
- Added `validMetrics` filtering to prevent processing null objects
- Safe property extraction for all metric value access
- Maintains full backward compatibility

## 🧪 Testing
- ✅ Fixed the specific error at line 1095
- ✅ Works with Omar's HR format (`last_reading` instead of `avg`)  
- ✅ Maintains compatibility with original data format
- ✅ Handles edge cases with missing or null data

## 📈 Impact
- **Resolves final data format compatibility issue**
- **Enables reliable multi-day analysis for all users**
- **Robust error handling for various API response formats**
- **Future-proof against data structure variations**

Complements PR #1 to provide complete data format compatibility.